### PR TITLE
Add initial Verse module skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # GravityBox
+
+Initial Verse module structure for the GravityBox UEFN project. This repository contains
+placeholder devices and world setup scripts for a rotating-gravity arena game.
+

--- a/Verse/GravityBox.verse
+++ b/Verse/GravityBox.verse
@@ -1,0 +1,6 @@
+module GravityBox
+
+// Entry module referencing all game devices.
+// Additional game setup can be added here later.
+
+

--- a/Verse/GravityController.verse
+++ b/Verse/GravityController.verse
@@ -1,0 +1,59 @@
+module GravityBox
+
+// Device responsible for managing gravity shifts during the match
+class GravityController extends creative_device:
+    // Minimum seconds between gravity changes
+    GravityIntervalMin:float = 10.0
+    // Maximum seconds between gravity changes
+    GravityIntervalMax:float = 20.0
+
+    // Current gravity direction
+    var CurrentGravity:vector3 = vector3{X:=0.0, Y:=0.0, Z:=-1.0}
+
+    // Log category for debugging gravity
+    gravity_log := log("gravity_log")
+
+    // Called when the device is spawned at match start
+    OnBegin<override>()<suspends>:
+        SetGravity(CurrentGravity)
+        gravity_log("Initial gravity: {CurrentGravity}")
+        spawn{ManageGravity()}
+
+    // Main loop that changes gravity periodically
+    ManageGravity()<suspends>:
+        loop:
+            Sleep(RandomFloat(GravityIntervalMin, GravityIntervalMax))
+            NewDir := PickRandomGravity()
+            CurrentGravity := NewDir
+            SetGravity(NewDir)
+            BroadcastGravity(NewDir)
+            ReorientPlayers(NewDir)
+            gravity_log("Gravity changed to {NewDir}")
+
+    // Pick a random axis-aligned direction
+    PickRandomGravity():vector3=
+        dirs := array[
+            vector3{X:=1.0, Y:=0.0, Z:=0.0},
+            vector3{X:=-1.0, Y:=0.0, Z:=0.0},
+            vector3{X:=0.0, Y:=1.0, Z:=0.0},
+            vector3{X:=0.0, Y:=-1.0, Z:=0.0},
+            vector3{X:=0.0, Y:=0.0, Z:=1.0},
+            vector3{X:=0.0, Y:=0.0, Z:=-1.0}
+        ]
+        return dirs[RandomInt(0, dirs.length - 1)]
+
+    // Apply the gravity vector to the world (placeholder)
+    SetGravity(dir:vector3):void=
+        // TODO: implement actual world gravity change
+        pass
+
+    // Send the gravity vector to all players (placeholder)
+    BroadcastGravity(dir:vector3):void=
+        // TODO: broadcast to players via gameplay message or replication
+        pass
+
+    // Adjust each player's orientation after gravity change (placeholder)
+    ReorientPlayers(dir:vector3):void=
+        // TODO: rotate players to new "down" direction
+        pass
+

--- a/Verse/LootDistributor.verse
+++ b/Verse/LootDistributor.verse
@@ -1,0 +1,13 @@
+module GravityBox
+
+// Handles distribution of loot chests throughout the cube
+class LootDistributor extends creative_device:
+    // Called when the device begins play
+    OnBegin<override>()<suspends>:
+        DistributeLoot()
+
+    // Place loot chests in concentric rings from center outward
+    DistributeLoot()<suspends>:
+        // TODO: spawn loot with rarity decreasing toward the edges
+        pass
+

--- a/Verse/PlayerSpawner.verse
+++ b/Verse/PlayerSpawner.verse
@@ -1,0 +1,29 @@
+module GravityBox
+
+// Device that spawns players at the six faces of the cube
+class PlayerSpawner extends creative_device:
+    // List of transforms for each spawn location around the cube
+    SpawnPoints:array<transform> = array[]
+
+    // Called when the device is spawned
+    OnBegin<override>()<suspends>:
+        spawn{SpawnAllPlayers()}
+
+    // Spawn each player at a predefined face and align them with current gravity
+    SpawnAllPlayers()<suspends>:
+        players := GetPlaysers()
+        for i := 0..<(min(players.length, SpawnPoints.length)):
+            p := players[i]
+            SpawnPlayer(p, SpawnPoints[i])
+            AlignToGravity(p, GravityController.CurrentGravity)
+
+    // Spawn player at given transform (placeholder)
+    SpawnPlayer(p:player, t:transform)<suspends>:
+        # TODO: implement actual spawn logic
+        pass
+
+    // Align a player to match the current "down" direction (placeholder)
+    AlignToGravity(p:player, gravity:vector3):void=
+        # TODO: rotate player to face gravity direction
+        pass
+

--- a/Verse/WorldBuilder.verse
+++ b/Verse/WorldBuilder.verse
@@ -1,0 +1,14 @@
+module GravityBox
+
+// Responsible for constructing the destructible box grid and main arena
+class WorldBuilder extends creative_device:
+    // Called when the device begins play
+    OnBegin<override>()<suspends>:
+        BuildArena()
+
+    // Create destructible sub-cubes and keep main cube indestructible
+    BuildArena()<suspends>:
+        // TODO: spawn destructible cubes in a 3D grid
+        // TODO: ensure main cube walls are indestructible
+        pass
+


### PR DESCRIPTION
## Summary
- add readme overview
- create Verse module skeleton with GravityController
- add PlayerSpawner, LootDistributor, and WorldBuilder devices
- provide entry module file for GravityBox

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68413233ffac83208609ebdc175cc338